### PR TITLE
Fix bug: accel full scale select uses the [4:3] bits of the register

### DIFF
--- a/src/icm20602.c
+++ b/src/icm20602.c
@@ -238,7 +238,7 @@ icm20602_init(struct icm20602_dev * dev)
       ON_ERROR_GOTO((0 == r), return_err);
     }
 
-    tmp = (dev->accel_g) << 2;
+    tmp = (dev->accel_g) << 3;
     r = dev->hal_wr(dev->id, REG_ACCEL_CONFIG, &tmp, 1);
     ON_ERROR_GOTO((0 == r), return_err);
   }


### PR DESCRIPTION
As shown in Section 9.18 of the document, the accelerometer range setting uses the [4:3] bits of the register. I found that in a stationary state, the z-axis reads 2G. After checking the document, I identified the same issue as in [issues#1](https://github.com/mreutman/icm20602/issues/1).